### PR TITLE
Fixes for recent gcc and gforth

### DIFF
--- a/forth.c
+++ b/forth.c
@@ -3,8 +3,8 @@
  // A simple Reference implementation
 // for the Raillisp Forth Specification.
 
-#include <readline/readline.h>
 #include <stdio.h>
+#include <readline/readline.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>

--- a/raillisp.fth
+++ b/raillisp.fth
@@ -717,8 +717,21 @@ defer lisp-read-lisp
     r> drop ( drop tail) r> ( return first)
   then ;
 
+: lisp-s>number? ( a u -- n o b )
+  \ s>number?, except that - is not considered a number
+  dup 1 = if
+    drop dup c@ [char] - = if
+      drop 0 0 0
+    else
+      1 s>number?
+    then
+  else
+    s>number?
+  then
+;
+
 : lisp-read-symbol ( e a -- e a lisp )
-  lisp-read-token 2dup s>number? if
+  lisp-read-token 2dup lisp-s>number? if
     drop tag-num nip nip
   else
     2drop 2dup s" nil" compare 0= if
@@ -1511,7 +1524,7 @@ s" command-line-args" str-intern sym>value _command-line-args !
   r> -rot r> cmove )
 
 1 (defun str->int ( lisp - lisp )
-  symbol->string s>number? if drop tag-num else nil then )
+  symbol->string lisp-s>number? if drop tag-num else nil then )
 
 1 (defun make-empty-vec ( n - )
   \ Contains uninitialized lisp objects. Should ever be printed.


### PR DESCRIPTION
About first patch: On recent gcc versions (presumably), `<stdio.h>` needs to be included before `<readline/readline.h>`

About second patch: Not sure how this worked before, but `s>number?` thinks `-` is a number. Thus I implemented a custom version, to check for this case specifically.